### PR TITLE
fix(name-registry): re-registration of entries are possible

### DIFF
--- a/contracts/registry/SimpleRegistry.sol
+++ b/contracts/registry/SimpleRegistry.sol
@@ -38,10 +38,10 @@ import "./Registry.sol";
 
 
 contract SimpleRegistry is Ownable, MetadataRegistry, OwnerRegistry, ReverseRegistry {
+
     struct Entry {
         address owner;
         address reverse;
-        bool deleted;
         mapping (string => bytes32) data;
     }
 
@@ -54,7 +54,7 @@ contract SimpleRegistry is Ownable, MetadataRegistry, OwnerRegistry, ReverseRegi
 
     modifier whenUnreserved(bytes32 _name) {
         require(
-            entries[_name].owner == address(0) && !entries[_name].deleted,
+            entries[_name].owner == address(0),
             "Error: Only when unreserved");
         _;
     }
@@ -71,14 +71,14 @@ contract SimpleRegistry is Ownable, MetadataRegistry, OwnerRegistry, ReverseRegi
 
     modifier whenEntry(string memory _name) {
         require(
-            !entries[keccak256(bytes(_name))].deleted && entries[keccak256(bytes(_name))].owner != address(0),
+            entries[keccak256(bytes(_name))].owner != address(0),
             "Error: Only when entry");
         _;
     }
 
     modifier whenEntryRaw(bytes32 _name) {
         require(
-            !entries[_name].deleted && entries[_name].owner != address(0),
+            entries[_name].owner != address(0),
             "Error: Only when entry raw"
         );
         _;
@@ -122,7 +122,7 @@ contract SimpleRegistry is Ownable, MetadataRegistry, OwnerRegistry, ReverseRegi
             emit ReverseRemoved(reverses[entries[_name].reverse], entries[_name].reverse);
             delete reverses[entries[_name].reverse];
         }
-        entries[_name].deleted = true;
+        delete entries[_name];
         emit Dropped(_name, msg.sender);
         return true;
     }

--- a/test/registry/simple_registry_test.js
+++ b/test/registry/simple_registry_test.js
@@ -252,6 +252,13 @@ contract("SimpleRegistry", accounts => {
     assert(txReturn.logs[0].args.owner === accounts[1], "Should have the right oldOwner");
   });
 
+  it("should allow to re-reserve a dropped name", async () => {
+    const testReg = await SimpleRegistry.new(address, { from: address });
+    await testReg.reserve(name, { from: address });
+    await testReg.drop(name, { from: address });
+    await testReg.reserve(name, { from: address });
+  });
+
   it("should not try to delete unconfirmed reverse entry on a drop", async () => {
     const testReg = await SimpleRegistry.new(address, { from: address });
 
@@ -324,11 +331,11 @@ contract("SimpleRegistry", accounts => {
       from: address
     });
 
-    assert(txReturn.logs[0].event == "ReverseRemoved", "Should have thrown the event")
+    assert(txReturn.logs[0].event == "ReverseRemoved", "Should have thrown the event");
     assert(txReturn.logs[0].args.name === nameEntry, "Should have the right name");
     assert(txReturn.logs[0].args.reverse === address, "Should have the right oldOwner");
 
-    assert(txReturn.logs[1].event == "Dropped", "Should have thrown the event")
+    assert(txReturn.logs[1].event == "Dropped", "Should have thrown the event");
     assert(txReturn.logs[1].args.name === name, "Should have the right name");
     assert(txReturn.logs[1].args.owner === address, "Should have the right oldOwner");
 


### PR DESCRIPTION
- removed the delete flag from entries
- occupancy is checked by owner addresses
- minor formatting alignment

Closes #44 